### PR TITLE
docs(formatting): update documentation files for nextra compatibility

### DIFF
--- a/.github/workflows/mirror-docs-to-docviewer.yml
+++ b/.github/workflows/mirror-docs-to-docviewer.yml
@@ -30,7 +30,7 @@ jobs:
           REPO_NAME=$(basename $GITHUB_REPOSITORY)
           echo "REPO_NAME=$REPO_NAME" >> $GITHUB_OUTPUT
 
-          KEBAB_CASE_REPO_NAME=$(echo "$REPO_NAME" | sed -E 's/([a-z0-9])([A-Z])/\1-\2/g; s/_/-/g' | tr '[:upper:]' '[:lower:]')
+          KEBAB_CASE_REPO_NAME=$(echo "$REPO_NAME" | tr '[:upper:]' '[:lower:]' | sed 's/_/-/g')
           echo "KEBAB_CASE_REPO_NAME=$KEBAB_CASE_REPO_NAME" >> $GITHUB_OUTPUT
 
           TIMESTAMP=$(date +%Y%m%d%H%M%S)
@@ -65,7 +65,7 @@ jobs:
           echo "Using branch name: $BRANCH_NAME"
           git checkout -b "$BRANCH_NAME"
 
-          TARGET_DIR="src/app/${{ steps.vars.outputs.KEBAB_CASE_REPO_NAME }}"
+          TARGET_DIR="src/app/docs/${{ steps.vars.outputs.KEBAB_CASE_REPO_NAME }}"
           mkdir -p "$TARGET_DIR"
 
           cp -r ../source/docs/* "$TARGET_DIR/"

--- a/docs/_meta.js
+++ b/docs/_meta.js
@@ -1,8 +1,8 @@
-{
-	"_": "Introduction",
+export default {
 	"api-reference": "API Reference",
 	"core-concepts": "Core Concepts",
 	"getting-started": "Getting Started",
-	"services": "Services",
-	"utilities": "Utilities"
-}
+	index: "Introduction",
+	services: "Services",
+	utilities: "Utilities",
+};

--- a/docs/api-reference/_meta.js
+++ b/docs/api-reference/_meta.js
@@ -1,0 +1,5 @@
+export default {
+	enums: "Enums",
+	index: "Overview",
+	interfaces: "Interfaces",
+};

--- a/docs/api-reference/_meta.json
+++ b/docs/api-reference/_meta.json
@@ -1,5 +1,0 @@
-{
-	"enums": "Enums",
-	"index": "Overview",
-	"interfaces": "Interfaces"
-}

--- a/docs/api-reference/enums/page.mdx
+++ b/docs/api-reference/enums/page.mdx
@@ -6,7 +6,7 @@
 
 Defines the available log levels for the `ILogger`.
 
-```typescript
+```typescript copy
 export enum ELoggerLogLevel {
 	DEBUG = "debug",
 	ERROR = "error",
@@ -17,15 +17,15 @@ export enum ELoggerLogLevel {
 ```
 
 - **Hierarchy**: `TRACE` > `DEBUG` > `INFO` > `WARN` > `ERROR` (most verbose to least verbose).
-- **Usage**: Used in [`IConsoleLoggerOptions`](../interfaces#iconsoleloggeroptions) to set the minimum logging level.
+- **Usage**: Used in [`IConsoleLoggerOptions`](/api-reference/interfaces#iconsoleloggeroptions) to set the minimum logging level.
 
 ## `EServiceToken`
 
 *Defined in: `src/domain/enum/service-token.enum.ts`*
 
-Defines standard `symbol` tokens for commonly used services within the [`IContainer`](../interfaces#icontainer).
+Defines standard `symbol` tokens for commonly used services within the [`IContainer`](/api-reference/interfaces#icontainer).
 
-```typescript
+```typescript copy
 export enum EServiceToken {
 	CONTAINER = "container", // Typically used to register the container itself
 	FACTORY = "factory",     // For the main application Factory

--- a/docs/api-reference/interfaces/page.mdx
+++ b/docs/api-reference/interfaces/page.mdx
@@ -9,7 +9,7 @@ This page details the core interfaces used throughout the library.
 Defines the contract for a dependency injection container.
 *Defined in: `src/domain/interface/container.interface.ts`*
 
-```typescript
+```typescript copy
 export interface IContainer {
 	clear(): void;
 	get<T>(token: symbol): T | undefined;
@@ -22,14 +22,14 @@ export interface IContainer {
 	unregisterMany(tokens: Array<symbol>): void;
 }
 ```
-*(See Core Concepts: [Dependency Injection](../../core-concepts/container))* 
+*(See Core Concepts: [Dependency Injection](/core-concepts/container))* 
 
 ### `IRegistry<T>`
 
 Defines the contract for a registry storing items of type `T`, where `T` must have a `name: string` property.
 *Defined in: `src/domain/interface/registry.interface.ts`*
 
-```typescript
+```typescript copy
 export interface IRegistry<T extends { name: string }> {
 	clear(): void;
 	get(name: string): T | undefined;
@@ -42,27 +42,27 @@ export interface IRegistry<T extends { name: string }> {
 	unregisterMany(names: Array<string>): void;
 }
 ```
-*(See Core Concepts: [Registry Pattern](../../core-concepts/registry))* 
+*(See Core Concepts: [Registry Pattern](/core-concepts/registry))* 
 
 ### `IFactory<T>`
 
 Defines the contract for a factory creating items of type `T`.
 *Defined in: `src/domain/interface/factory.interface.ts`*
 
-```typescript
+```typescript copy
 export interface IFactory<T> {
 	create(name: string): T;
 	getRegistry(): IRegistry<T>;
 }
 ```
-*(See Core Concepts: [Factory Pattern](../../core-concepts/factory))* 
+*(See Core Concepts: [Factory Pattern](/core-concepts/factory))* 
 
 ### `ILogger`
 
 Defines the contract for a logging service.
 *Defined in: `src/domain/interface/logger/interface.ts`*
 
-```typescript
+```typescript copy
 export interface ILogger {
 	debug(message: string, options?: ILoggerMethodOptions): void;
 	error(message: string, options?: ILoggerMethodOptions): void;
@@ -71,21 +71,21 @@ export interface ILogger {
 	warn(message: string, options?: ILoggerMethodOptions): void;
 }
 ```
-*(See Services: [Logging Service](../../services/logging))* 
+*(See Services: [Logging Service](/services/logging))* 
 
 ### `IError`
 
 Extends the standard `Error` interface with additional structured properties.
 *Defined in: `src/domain/interface/error.interface.ts`*
 
-```typescript
+```typescript copy
 export interface IError extends Error {
 	CODE: string;
 	CAUSE?: Error;
 	context?: Record<string, unknown>;
 }
 ```
-*(See Core Concepts: [Error Handling](../../core-concepts/error-handling))* 
+*(See Core Concepts: [Error Handling](/core-concepts/error-handling))* 
 
 ## Options Interfaces
 
@@ -96,7 +96,7 @@ These interfaces define the configuration options for creating instances of the 
 Options for `BaseContainer`.
 *Defined in: `src/infrastructure/interface/base/container-options.interface.ts`*
 
-```typescript
+```typescript copy
 export interface IBaseContainerOptions {
 	logger?: ILogger;
 }
@@ -107,7 +107,7 @@ export interface IBaseContainerOptions {
 Options for `BaseRegistry`.
 *Defined in: `src/infrastructure/interface/base/registry-options.interface.ts`*
 
-```typescript
+```typescript copy
 export interface IBaseRegistryOptions {
 	logger?: ILogger;
 }
@@ -118,7 +118,7 @@ export interface IBaseRegistryOptions {
 Options for `BaseFactory`.
 *Defined in: `src/infrastructure/interface/base/factory-options.interface.ts`*
 
-```typescript
+```typescript copy
 export interface IBaseFactoryOptions<T> {
 	logger?: ILogger;
 	registry: IRegistry<T>;
@@ -131,9 +131,9 @@ export interface IBaseFactoryOptions<T> {
 Options for `ConsoleLoggerService`.
 *Defined in: `src/infrastructure/interface/console-logger-options.interface.ts`*
 
-```typescript
+```typescript copy
 export interface IConsoleLoggerOptions {
-	level: ELoggerLogLevel; // Minimum level to log - See ELoggerLogLevel in Enums
+	level: ELoggerLogLevel; // Minimum level to log - See [ELoggerLogLevel](/api-reference/enums#eloggerloglevel)
 	source?: string; // Default source identifier for the logger instance
 }
 ```
@@ -143,7 +143,7 @@ export interface IConsoleLoggerOptions {
 Options passed to individual `ILogger` methods.
 *Defined in: `src/domain/interface/logger/method-options.interface.ts`*
 
-```typescript
+```typescript copy
 export interface ILoggerMethodOptions {
 	context?: Record<string, unknown>; // Additional data for this specific log entry
 	source?: string; // Overrides the logger's default source for this entry
@@ -155,7 +155,7 @@ export interface ILoggerMethodOptions {
 Options for `BaseError` constructor.
 *Defined in: `src/infrastructure/interface/base/error-options.interface.ts`*
 
-```typescript
+```typescript copy
 export interface IBaseErrorOptions {
 	cause?: Error;
 	code: string;
@@ -169,7 +169,7 @@ export interface IBaseErrorOptions {
 Options for the `CoreFactory` singleton.
 *Defined in: `src/infrastructure/interface/core-factory-options.interface.ts`*
 
-```typescript
+```typescript copy
 export interface ICoreFactoryOptions {
 	logger?: ILogger;
 }

--- a/docs/api-reference/page.mdx
+++ b/docs/api-reference/page.mdx
@@ -1,6 +1,6 @@
-# API Reference Overview
+# Overview
 
 This section provides detailed reference documentation for the public Enums and Interfaces exposed by the library.
 
-- **[Enums](./enums)**: Constant values used within the library.
-- **[Interfaces](./interfaces)**: Type definitions and contracts for core components and options. 
+- **[Enums](/api-reference/enums)**: Constant values used within the library.
+- **[Interfaces](/api-reference/interfaces)**: Type definitions and contracts for core components and options. 

--- a/docs/core-concepts/_meta.js
+++ b/docs/core-concepts/_meta.js
@@ -1,0 +1,7 @@
+export default {
+	container: "Dependency Injection (Container)",
+	"error-handling": "Error Handling",
+	factory: "Factory Pattern",
+	index: "Overview",
+	registry: "Registry Pattern",
+};

--- a/docs/core-concepts/_meta.json
+++ b/docs/core-concepts/_meta.json
@@ -1,7 +1,0 @@
-{
-	"_": "Overview",
-	"container": "Dependency Injection (Container)",
-	"error-handling": "Error Handling",
-	"factory": "Factory Pattern",
-	"registry": "Registry Pattern"
-}

--- a/docs/core-concepts/container/page.mdx
+++ b/docs/core-concepts/container/page.mdx
@@ -8,7 +8,7 @@ Think of the container as a central hub where you register all the building bloc
 
 - **Registration (`register`/`registerMany`)**: Store dependencies using a unique `symbol` as a key (token). You can use predefined `EServiceToken` for core services or create your own `Symbol.for('YourToken')` for application-specific dependencies.
 
-  ```typescript filename="src/container-setup.ts"
+  ```typescript filename="src/container-setup.ts" copy
   import { createContainer, EServiceToken, type ILogger } from '@elsikora/cladi';
   import { SomeService, AnotherService } from './services';
   import { ApiConfig } from './config';
@@ -42,7 +42,7 @@ Think of the container as a central hub where you register all the building bloc
 
 - **Retrieval (`get`/`getMany`)**: Fetch dependencies using their registered token. The type parameter `<T>` ensures type safety.
 
-  ```typescript filename="src/some-module.ts"
+  ```typescript filename="src/some-module.ts" copy
   import { container, Tokens } from './container-setup';
   import { type ILogger, EServiceToken } from '@elsikora/cladi';
   import type { SomeService } from './services';
@@ -66,7 +66,7 @@ Think of the container as a central hub where you register all the building bloc
   ```
 
 - **Checking Existence (`has`)**: Verify if a token is registered before attempting retrieval.
-  ```typescript
+  ```typescript copy
   declare const logger: ILogger;
   if (container.has(Tokens.SomeService)) {
     const service = container.get<SomeService>(Tokens.SomeService);
@@ -77,14 +77,14 @@ Think of the container as a central hub where you register all the building bloc
   ```
 
 - **Unregistration (`unregister`/`unregisterMany`)**: Remove dependencies, useful in testing or dynamic scenarios (less common in typical application flow).
-  ```typescript
+  ```typescript copy
   declare const logger: ILogger;
   container.unregister(Tokens.SomeService);
   logger.debug(`Has SomeService after unregister: ${container.has(Tokens.SomeService)}`); // Logs: false
   ```
 
 - **Clearing (`clear`)**: Remove all registered dependencies, primarily for test environment teardown to ensure test isolation.
-  ```typescript
+  ```typescript copy
   declare const logger: ILogger;
   container.clear();
   logger.debug(`Has Logger after clear: ${container.has(EServiceToken.LOGGER)}`); // Logs: false

--- a/docs/core-concepts/error-handling/page.mdx
+++ b/docs/core-concepts/error-handling/page.mdx
@@ -6,7 +6,7 @@
 
 This is the core contract for errors within the library. It extends the built-in `Error` and adds fields crucial for robust error management:
 
-```typescript
+```typescript copy
 // Located in: src/domain/interface/error.interface.ts
 export interface IError extends Error {
   /**
@@ -34,7 +34,7 @@ export interface IError extends Error {
 
 This is the concrete implementation of `IError` provided by the library. Use it to throw structured errors from your own code or within library extensions.
 
-```typescript filename="src/data-service.ts"
+```typescript filename="src/data-service.ts" copy
 import { BaseError } from '@elsikora/cladi';
 
 // Assume item is declared elsewhere
@@ -132,4 +132,4 @@ async function processItem(id: string) {
 
 - **`IError` (Interface)**: Located in `src/domain/interface/error.interface.ts`.
 - **`BaseError` (Class)**: Located in `src/infrastructure/class/base/error.class.ts`. Implements `IError` and captures stack traces.
-- **`IBaseErrorOptions` (Interface)**: Located in `src/infrastructure/interface/base/error-options.interface.ts`. Defines the options object passed to the `BaseError` constructor. 
+- **`IBaseErrorOptions` (Interface)**: Located in `src/infrastructure/interface/base/error-options.interface.ts`. Defines the options object passed to the `BaseError`

--- a/docs/core-concepts/factory/page.mdx
+++ b/docs/core-concepts/factory/page.mdx
@@ -1,15 +1,15 @@
 # Factory Pattern
 
-The `Factory` pattern, implemented via `IFactory` and `BaseFactory`, provides a standardized way to create instances of objects based on named templates stored in a [`Registry`](../registry).
+The `Factory` pattern, implemented via `IFactory` and `BaseFactory`, provides a standardized way to create instances of objects based on named templates stored in a [`Registry`](/core-concepts/registry).
 
 Instead of scattering `new MyObject(...)` calls throughout your code, you ask the factory to `create('objectName')`.
 This centralizes creation logic and makes it easy to switch out implementations or configurations.
 
 ## Key Features & Examples
 
-- **Creation (`create`)**: The core method. It takes a `name`, looks up the corresponding template object in its associated [`Registry`](../registry), clones it (by default using `structuredClone`), potentially transforms it, caches it, and returns the final instance.
+- **Creation (`create`)**: The core method. It takes a `name`, looks up the corresponding template object in its associated [`Registry`](/core-concepts/registry), clones it (by default using `structuredClone`), potentially transforms it, caches it, and returns the final instance.
 
-  ```typescript filename="src/user-factory.ts"
+  ```typescript filename="src/user-factory.ts" copy
   import { createFactory, createRegistry, type IFactory, type IRegistry } from '@elsikora/cladi';
 
   // Define user profile structure
@@ -62,7 +62,7 @@ This centralizes creation logic and makes it easy to switch out implementations 
 
 - **Optional Transformation (`transformer`)**: You can provide a function (`IBaseFactoryOptions.transformer`) that takes the template from the registry and returns a modified version *before* it's cached and cloned by the factory. This is useful for applying defaults, adding dynamic properties, or performing complex setup.
 
-  ```typescript
+  ```typescript copy
   // ... registry setup as before ...
 
   // Assume userRegistry is declared and populated
@@ -85,14 +85,14 @@ This centralizes creation logic and makes it easy to switch out implementations 
 
 - **Caching (Internal)**: The `BaseFactory` caches the *first transformed template* for each name. Subsequent calls to `create` for the same name will `structuredClone` this cached template, avoiding repeated lookups and transformations.
 
-- **Cache Clearing (`clearCache`)**: If the underlying [`Registry`](../registry) changes, you *must* call `factory.clearCache(name?)` to remove the factory's cached template(s) and force it to re-fetch (and re-transform) from the registry on the next `create` call. If `name` is omitted, the entire factory cache is cleared.
+- **Cache Clearing (`clearCache`)**: If the underlying [`Registry`](/core-concepts/registry) changes, you *must* call `factory.clearCache(name?)` to remove the factory's cached template(s) and force it to re-fetch (and re-transform) from the registry on the next `create` call. If `name` is omitted, the entire factory cache is cleared.
 
 ## Purpose & Use Cases
 
 - **Decouple Object Creation**: Hides the complexity of creating objects (`new ...`, setting defaults, etc.) behind a simple `create(name)` interface.
 - **Manage Instance Variations**: Easily create different pre-configured instances of the same base object type (like user profiles, database connections, API clients).
 - **Enforce Consistency**: Ensures objects are created according to the defined templates in the registry.
-- **Combine with DI**: Factories themselves can be registered in the [`Container`](../container) to provide on-demand creation of specific object types throughout the application.
+- **Combine with DI**: Factories themselves can be registered in the [`Container`](/core-concepts/container) to provide on-demand creation of specific object types throughout the application.
 
 ## Core Implementation
 

--- a/docs/core-concepts/page.mdx
+++ b/docs/core-concepts/page.mdx
@@ -1,9 +1,9 @@
-# Core Concepts Overview
+# Overview
 
 This section delves into the fundamental design patterns and concepts employed within the library.
 Understanding these concepts is key to effectively using the provided utilities.
 
-- **[Dependency Injection (Container)](./container)**: Learn how the `Container` manages dependencies and promotes loose coupling.
-- **[Registry Pattern](./registry)**: Discover how the `Registry` is used to store and retrieve named templates or configurations.
-- **[Factory Pattern](./factory)**: See how the `Factory` utilizes the `Registry` to create instances of objects.
-- **[Error Handling](./error-handling)**: Understand the standardized `Error` structure used throughout the library. 
+- **[Dependency Injection (Container)](/core-concepts/container)**: Learn how the `Container` manages dependencies and promotes loose coupling.
+- **[Registry Pattern](/core-concepts/registry)**: Discover how the `Registry` is used to store and retrieve named templates or configurations.
+- **[Factory Pattern](/core-concepts/factory)**: See how the `Factory` utilizes the `Registry` to create instances of objects.
+- **[Error Handling](/core-concepts/error-handling)**: Understand the standardized `Error` structure used throughout the library. 

--- a/docs/core-concepts/registry/page.mdx
+++ b/docs/core-concepts/registry/page.mdx
@@ -1,7 +1,7 @@
 # Registry Pattern
 
 The `Registry` pattern, implemented by `IRegistry` and `BaseRegistry`, provides a way to store and retrieve objects or configuration templates using a simple string name.
-It's often used as the data source for a [Factory](../factory).
+It's often used as the data source for a [Factory](/core-concepts/factory).
 
 Imagine needing different sets of configuration for different environments (dev, staging, prod) or different types of resources (small server, large server). A Registry is ideal for managing these named variations.
 
@@ -9,7 +9,7 @@ Imagine needing different sets of configuration for different environments (dev,
 
 - **Registration (`register`/`registerMany`)**: Store items. Each item **must** have a `name: string` property that serves as its unique key.
 
-  ```typescript filename="src/config-registry.ts"
+  ```typescript filename="src/config-registry.ts" copy
   import { createRegistry, type IRegistry } from '@elsikora/cladi';
 
   // Define the structure of our configuration objects
@@ -45,7 +45,7 @@ Imagine needing different sets of configuration for different environments (dev,
 
 - **Retrieval (`get`/`getMany`/`getAll`)**: Fetch items by their registered name(s). `getAll` retrieves all registered items.
 
-  ```typescript
+  ```typescript copy
   // Assuming registry from previous example
 
   const devConfig = registry.get("standard-dev");
@@ -62,20 +62,20 @@ Imagine needing different sets of configuration for different environments (dev,
   ```
 
 - **Checking Existence (`has`)**: Quickly check if a name is registered without retrieving the object.
-  ```typescript
+  ```typescript copy
   if (registry.has("high-mem-prod")) {
     console.log("Production configuration is available.");
   }
   ```
 
 - **Unregistration (`unregister`/`unregisterMany`)**: Remove items by name.
-  ```typescript
+  ```typescript copy
   registry.unregister("standard-dev");
   console.log(`Registry contains 'standard-dev' after unregister: ${registry.has("standard-dev")}`); // false
   ```
 
 - **Clearing (`clear`)**: Empty the entire registry.
-  ```typescript
+  ```typescript copy
   registry.clear();
   console.log(`Total configs after clear: ${registry.getAll().length}`); // 0
   ```
@@ -86,7 +86,7 @@ Imagine needing different sets of configuration for different environments (dev,
 
 - **Managing Variations**: Store different versions or configurations of an object (e.g., environment settings, feature flag states, UI themes, resource definitions).
 - **Decoupling Definitions**: Separates the *definition* of these variations from the code that *uses* them.
-- **Data Source for Factories**: Provide the named templates that a [Factory](../factory) will use to create actual instances.
+- **Data Source for Factories**: Provide the named templates that a [Factory](/core-concepts/factory) will use to create actual instances.
 
 ## Core Implementation
 

--- a/docs/getting-started/page.mdx
+++ b/docs/getting-started/page.mdx
@@ -4,7 +4,7 @@ This guide will walk you through the basic setup and usage of the core utilities
 
 ## Installation
 
-```bash
+```bash copy
 # Using npm
 npm install @elsikora/cladi
 
@@ -19,7 +19,7 @@ pnpm add @elsikora/cladi
 
 Here's a simple example of creating and using the core components:
 
-```typescript
+```typescript copy
 import {
 	createContainer,
 	createRegistry,
@@ -72,7 +72,7 @@ Let's structure a small application using `@elsikora/cladi`.
 
 **1. Define Types (`src/types.ts`)**
 
-```typescript filename="src/types.ts"
+```typescript filename="src/types.ts" copy
 // Define configuration structure
 export interface IAppConfig {
   name: string; // Required for Registry
@@ -94,7 +94,7 @@ export const ServiceTokens = {
 
 **2. Create Services (`src/services.ts`)**
 
-```typescript filename="src/services.ts"
+```typescript filename="src/services.ts" copy
 import type { IUserService, IAppConfig } from "./types";
 import type { ILogger } from "@elsikora/cladi";
 
@@ -121,7 +121,7 @@ export class UserServiceImpl implements IUserService {
 
 **3. Configure Container (`src/container.ts`)**
 
-```typescript filename="src/container-config.ts"
+```typescript filename="src/container-config.ts" copy
 import {
   createContainer,
   createRegistry,
@@ -182,7 +182,7 @@ export { container }; // Export the configured container
 
 **4. Application Entry Point (`src/main.ts`)**
 
-```typescript filename="src/main.ts"
+```typescript filename="src/main.ts" copy
 import { container } from "./container-config";
 import { type IUserService, ServiceTokens } from "./types";
 import { EServiceToken, type ILogger } from "@elsikora/cladi";

--- a/docs/services/_meta.js
+++ b/docs/services/_meta.js
@@ -1,0 +1,4 @@
+export default {
+	index: "Overview",
+	logging: "Logging Service",
+};

--- a/docs/services/_meta.json
+++ b/docs/services/_meta.json
@@ -1,4 +1,0 @@
-{
-	"index": "Overview",
-	"logging": "Logging Service"
-}

--- a/docs/services/logging/page.mdx
+++ b/docs/services/logging/page.mdx
@@ -6,7 +6,7 @@ Effective logging is crucial for understanding application behavior and debuggin
 
 This defines the standard contract for any logger implementation. It includes methods for different severity levels:
 
-```typescript
+```typescript copy
 // Located in: src/domain/interface/logger/interface.ts
 export interface ILogger {
   debug(message: string, options?: ILoggerMethodOptions): void;
@@ -42,7 +42,7 @@ This is the default implementation provided, suitable for most Node.js and brows
 
 **Example Usage:**
 
-```typescript filename="src/logging-example.ts"
+```typescript filename="src/logging-example.ts" copy
 import { createLogger, ELoggerLogLevel, type ILogger } from '@elsikora/cladi';
 
 // Create a logger instance
@@ -97,7 +97,7 @@ logger.trace("Detailed trace message - only shown if level is TRACE"); // Won't 
 
 The easiest way to get a `ConsoleLoggerService` instance is via the `createLogger` helper:
 
-```typescript
+```typescript copy
 import { createLogger, ELoggerLogLevel } from '@elsikora/cladi';
 
 // Logger with default level (INFO) and no source
@@ -112,36 +112,6 @@ const debugLogger = createLogger({
 
 ## Integrating with Dependency Injection
 
-Typically, you create a logger instance early in your application setup and register it with the [`Container`](../../core-concepts/container) using `EServiceToken.LOGGER`. Other services can then receive the logger via constructor injection.
+Typically, you create a logger instance early in your application setup and register it with the [`Container`](/core-concepts/container) using `EServiceToken.LOGGER`. Other services can then receive the logger via constructor injection.
 
-```typescript filename="src/container-setup.ts"
-// ... other imports
-import { createLogger, EServiceToken, ELoggerLogLevel, type ILogger, createContainer, type IContainer } from '@elsikora/cladi';
-
-const logger = createLogger({ level: ELoggerLogLevel.INFO, source: "App" });
-const container = createContainer({ logger }); // Optionally log container operations
-
-container.register(EServiceToken.LOGGER, logger);
-
-// ... register other services that depend on ILogger ...
 ```
-
-```typescript filename="src/some-service.ts"
-import { EServiceToken, type ILogger, type IContainer } from '@elsikora/cladi';
-// Assume container is accessible or passed in
-declare const container: IContainer;
-
-class SomeService {
-  private logger: ILogger;
-
-  constructor() {
-    // Retrieve logger from container
-    this.logger = container.get<ILogger>(EServiceToken.LOGGER)!;
-    this.logger.info("SomeService initialized", { source: "SomeService" });
-  }
-
-  doWork() {
-    this.logger.debug("Doing work...", { source: "SomeService" });
-  }
-}
-``` 

--- a/docs/services/page.mdx
+++ b/docs/services/page.mdx
@@ -1,6 +1,6 @@
-# Services Overview
+# Overview
 
 This section describes the services provided by the library.
 Services typically encapsulate reusable functionality or interact with external systems.
 
-- **[Logging Service](./logging)**: Learn about the standard logging interface and the provided console implementation. 
+- **[Logging Service](/services/logging)**: Learn about the standard logging interface and the provided console implementation.

--- a/docs/utilities/_meta.js
+++ b/docs/utilities/_meta.js
@@ -1,0 +1,4 @@
+export default {
+	"creation-helpers": "Creation Helpers",
+	index: "Overview",
+};

--- a/docs/utilities/_meta.json
+++ b/docs/utilities/_meta.json
@@ -1,4 +1,0 @@
-{
-	"_": "Overview",
-	"creation-helpers": "Creation Helpers"
-}

--- a/docs/utilities/creation-helpers/page.mdx
+++ b/docs/utilities/creation-helpers/page.mdx
@@ -8,7 +8,7 @@ These helpers simplify setup and reduce boilerplate code.
 
 Instantiates `BaseContainer` (which implements `IContainer`).
 
-```typescript filename="src/container-setup.ts"
+```typescript filename="src/container-setup.ts" copy
 import { createContainer, type IBaseContainerOptions, type IContainer, type ILogger } from '@elsikora/cladi';
 
 // Assuming logger is created
@@ -27,13 +27,13 @@ const container2: IContainer = createContainer(containerOptions);
 
 - **Purpose**: Quickly get a dependency injection container ready for registrations.
 - **Options (`IBaseContainerOptions`)**: Allows injecting a logger to monitor the container's own actions (register, get, etc.).
-- **See Also**: [Core Concepts: Container](../../core-concepts/container)
+- **See Also**: [Core Concepts: Container](/core-concepts/container)
 
 ## `createRegistry<T>`
 
 Instantiates `BaseRegistry<T>` (which implements `IRegistry<T>`). Requires a type parameter `T` that extends `{ name: string }`.
 
-```typescript filename="src/registry-setup.ts"
+```typescript filename="src/registry-setup.ts" copy
 import { createRegistry, type IBaseRegistryOptions, type IRegistry, type ILogger } from '@elsikora/cladi';
 
 // Define the type of item the registry will hold
@@ -58,13 +58,13 @@ const registry2: IRegistry<ServiceEndpoint> = createRegistry<ServiceEndpoint>(re
 
 - **Purpose**: Set up a named collection for storing configuration templates or object prototypes.
 - **Options (`IBaseRegistryOptions`)**: Allows injecting a logger for monitoring registry operations.
-- **See Also**: [Core Concepts: Registry](../../core-concepts/registry)
+- **See Also**: [Core Concepts: Registry](/core-concepts/registry)
 
 ## `createFactory<T>`
 
 Instantiates `BaseFactory<T>` (which implements `IFactory<T>`). Requires a type parameter `T` and must be provided with an existing `IRegistry<T>` instance.
 
-```typescript filename="src/factory-setup.ts"
+```typescript filename="src/factory-setup.ts" copy
 import { createFactory, type IBaseFactoryOptions, type IFactory, type IRegistry, type ILogger } from '@elsikora/cladi';
 
 // Assume ServiceEndpoint and a populated registry instance exist
@@ -87,13 +87,13 @@ const factory: IFactory<ServiceEndpoint> = createFactory<ServiceEndpoint>(factor
 
 - **Purpose**: Create an object factory that uses a registry as its source for templates.
 - **Options (`IBaseFactoryOptions`)**: Requires `registry`. Optionally takes a `logger` and a `transformer` function.
-- **See Also**: [Core Concepts: Factory](../../core-concepts/factory)
+- **See Also**: [Core Concepts: Factory](/core-concepts/factory)
 
 ## `createLogger`
 
 Instantiates `ConsoleLoggerService` (which implements `ILogger`).
 
-```typescript filename="src/logger-setup.ts"
+```typescript filename="src/logger-setup.ts" copy
 import { createLogger, type IConsoleLoggerOptions, type ILogger, ELoggerLogLevel } from '@elsikora/cladi';
 
 // Option 1: Use defaults (LogLevel: INFO, no source)
@@ -111,4 +111,4 @@ customLogger.debug("Debug message from MyModule.");
 
 - **Purpose**: Quickly get a standard console logger instance.
 - **Options (`IConsoleLoggerOptions`)**: Allows setting the minimum `level` and a default `source` identifier.
-- **See Also**: [Services: Logging](../../services/logging) 
+- **See Also**: [Services: Logging](/services/logging) 

--- a/docs/utilities/page.mdx
+++ b/docs/utilities/page.mdx
@@ -1,5 +1,5 @@
-# Utilities Overview
+# Overview
 
 This section covers utility functions provided by the library to simplify common tasks.
 
-- **[Creation Helpers](./creation-helpers)**: Functions to easily instantiate core components like Containers, Registries, Factories, and Loggers. 
+- **[Creation Helpers](/utilities/creation-helpers)**: Functions to easily instantiate core components like Containers, Registries, Factories, and Loggers. 


### PR DESCRIPTION
Updated documentation files to be compatible with Nextra framework requirements:
- Changed _meta.json files to _meta.js with export default format
- Updated internal links to use absolute paths
- Added 'copy' directive to code blocks
- Fixed target directory path in mirror workflow to include 'docs/' prefix
- Fixed kebab case conversion script to handle repository names correctly.