### PR TITLE
chore(repository): update repository url to cladi

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,6 +8,10 @@
 		"registry",
 		"clean-architecture"
 	],
+	"repository": {
+		"type": "git",
+		"url": "https://github.com/ElsiKora/ClaDI"
+	},
 	"license": "MIT",
 	"author": "ElsiKora",
 	"type": "module",

--- a/release.config.js
+++ b/release.config.js
@@ -46,7 +46,7 @@ const config = {
 			},
 		],
 	],
-	repositoryUrl: "https://github.com/ElsiKora/Bootstrap",
+	repositoryUrl: "https://github.com/ElsiKora/ClaDI",
 };
 
 const isPrereleaseBranch = config.branches.some((b) => typeof b === "object" && branch.includes(b.name) && b.prerelease);


### PR DESCRIPTION
Updated the repository URL in package.json and release.config.js to point to the correct GitHub repository. Added missing repository field in package.json.