### PR TITLE
chore(npm): add publishconfig for public package access

### DIFF
--- a/package.json
+++ b/package.json
@@ -82,5 +82,8 @@
 		"typescript": "^5.8.3",
 		"vite-tsconfig-paths": "^5.1.4",
 		"vitest": "^3.1.1"
+	},
+	"publishConfig": {
+		"access": "public"
 	}
 }


### PR DESCRIPTION
Added publishConfig with 'access' set to 'public' in package.json to ensure the package can be published to npm registry as a public package.