### PR TITLE
docs(logger): add default value annotation for console logger level o…

### DIFF
--- a/src/infrastructure/interface/console-logger-options.interface.ts
+++ b/src/infrastructure/interface/console-logger-options.interface.ts
@@ -6,6 +6,7 @@ import type { ELoggerLogLevel } from "@domain/enum";
 export interface IConsoleLoggerOptions {
 	/**
 	 * The log level to use.
+	 * @default ELoggerLogLevel.INFO
 	 */
 	level: ELoggerLogLevel;
 


### PR DESCRIPTION
…ption

Added JSDoc default annotation to clarify that the default log level for the console logger is INFO. This improves developer experience by making the default configuration more obvious in the interface documentation.