### PR TITLE
docs(nextra): update documentation structure for nextra integration

### DIFF
--- a/docs/_meta.js
+++ b/docs/_meta.js
@@ -1,8 +1,8 @@
+/* eslint-disable @elsikora/perfectionist/sort-objects */
 export default {
+	"getting-started": "Getting Started",
 	"api-reference": "API Reference",
 	"core-concepts": "Core Concepts",
-	"getting-started": "Getting Started",
-	index: "Introduction",
 	services: "Services",
 	utilities: "Utilities",
 };

--- a/docs/api-reference/_meta.js
+++ b/docs/api-reference/_meta.js
@@ -1,5 +1,4 @@
 export default {
 	enums: "Enums",
-	index: "Overview",
 	interfaces: "Interfaces",
 };

--- a/docs/api-reference/enums/page.mdx
+++ b/docs/api-reference/enums/page.mdx
@@ -6,7 +6,7 @@
 
 Defines the available log levels for the `ILogger`.
 
-```typescript copy
+```typescript filename="src/domain/enum/logger-log-level.enum.ts" copy
 export enum ELoggerLogLevel {
 	DEBUG = "debug",
 	ERROR = "error",
@@ -17,15 +17,15 @@ export enum ELoggerLogLevel {
 ```
 
 - **Hierarchy**: `TRACE` > `DEBUG` > `INFO` > `WARN` > `ERROR` (most verbose to least verbose).
-- **Usage**: Used in [`IConsoleLoggerOptions`](/api-reference/interfaces#iconsoleloggeroptions) to set the minimum logging level.
+- **Usage**: Used in [`IConsoleLoggerOptions`](/docs/cladi/api-reference/interfaces#iconsoleloggeroptions) to set the minimum logging level.
 
 ## `EServiceToken`
 
 *Defined in: `src/domain/enum/service-token.enum.ts`*
 
-Defines standard `symbol` tokens for commonly used services within the [`IContainer`](/api-reference/interfaces#icontainer).
+Defines standard `symbol` tokens for commonly used services within the [`IContainer`](/docs/cladi/api-reference/interfaces#icontainer).
 
-```typescript copy
+```typescript filename="src/domain/enum/service-token.enum.ts" copy
 export enum EServiceToken {
 	CONTAINER = "container", // Typically used to register the container itself
 	FACTORY = "factory",     // For the main application Factory
@@ -34,4 +34,4 @@ export enum EServiceToken {
 }
 ```
 
-- **Purpose**: Provides consistent, well-known symbols for core service registration and retrieval, reducing the need for custom symbols for basic services. 
+- **Purpose**: Provides consistent, well-known symbols for core service registration and retrieval, reducing the need for custom symbols for basic services.

--- a/docs/api-reference/interfaces/page.mdx
+++ b/docs/api-reference/interfaces/page.mdx
@@ -1,3 +1,5 @@
+import { unstable_TSDoc as TSDoc } from 'nextra/tsdoc'
+
 # Interfaces
 
 This page details the core interfaces used throughout the library.
@@ -9,168 +11,49 @@ This page details the core interfaces used throughout the library.
 Defines the contract for a dependency injection container.
 *Defined in: `src/domain/interface/container.interface.ts`*
 
-```typescript copy
-export interface IContainer {
-	clear(): void;
-	get<T>(token: symbol): T | undefined;
-	getAll(): Array<unknown>;
-	getMany<T>(tokens: Array<symbol>): Array<T>;
-	has(token: symbol): boolean;
-	register<T>(token: symbol, implementation: T): void;
-	registerMany<T>(tokens: Array<symbol>, implementations: Record<symbol, T>): void;
-	unregister(token: symbol): void;
-	unregisterMany(tokens: Array<symbol>): void;
-}
-```
-*(See Core Concepts: [Dependency Injection](/core-concepts/container))* 
+<TSDoc code={`import type { IContainer } from '@elsikora/cladi';
+export default IContainer`} />
+
+*(See Core Concepts: [Container Pattern](/docs/cladi/core-concepts/container))*
 
 ### `IRegistry<T>`
 
 Defines the contract for a registry storing items of type `T`, where `T` must have a `name: string` property.
 *Defined in: `src/domain/interface/registry.interface.ts`*
 
-```typescript copy
-export interface IRegistry<T extends { name: string }> {
-	clear(): void;
-	get(name: string): T | undefined;
-	getAll(): Array<T>;
-	getMany(names: Array<string>): Array<T>;
-	has(name: string): boolean;
-	register(item: T): void;
-	registerMany(items: Array<T>): void;
-	unregister(name: string): void;
-	unregisterMany(names: Array<string>): void;
-}
-```
-*(See Core Concepts: [Registry Pattern](/core-concepts/registry))* 
+<TSDoc code={`import type { IRegistry } from '@elsikora/cladi';
+export default IRegistry`} />
+
+*(See Core Concepts: [Registry Pattern](/docs/cladi/core-concepts/registry))*
 
 ### `IFactory<T>`
 
 Defines the contract for a factory creating items of type `T`.
 *Defined in: `src/domain/interface/factory.interface.ts`*
 
-```typescript copy
-export interface IFactory<T> {
-	create(name: string): T;
-	getRegistry(): IRegistry<T>;
-}
-```
-*(See Core Concepts: [Factory Pattern](/core-concepts/factory))* 
+<TSDoc code={`import type { IFactory } from '@elsikora/cladi';
+export default IFactory`} />
+
+*(See Core Concepts: [Factory Pattern](/docs/cladi/core-concepts/factory))*
 
 ### `ILogger`
 
 Defines the contract for a logging service.
 *Defined in: `src/domain/interface/logger/interface.ts`*
 
-```typescript copy
-export interface ILogger {
-	debug(message: string, options?: ILoggerMethodOptions): void;
-	error(message: string, options?: ILoggerMethodOptions): void;
-	info(message: string, options?: ILoggerMethodOptions): void;
-	trace(message: string, options?: ILoggerMethodOptions): void;
-	warn(message: string, options?: ILoggerMethodOptions): void;
-}
-```
-*(See Services: [Logging Service](/services/logging))* 
+<TSDoc code={`import type { ILogger, ILoggerMethodOptions } from '@elsikora/cladi';
+// We need to export both ILogger and ILoggerMethodOptions if ILogger references it
+export interface ProcessedLogger extends ILogger {} // Helper to ensure ILoggerMethodOptions is picked up if referenced
+export default ProcessedLogger`} />
+
+*(See Services: [Logging Service](/docs/cladi/services/logging))*
 
 ### `IError`
 
 Extends the standard `Error` interface with additional structured properties.
 *Defined in: `src/domain/interface/error.interface.ts`*
 
-```typescript copy
-export interface IError extends Error {
-	CODE: string;
-	CAUSE?: Error;
-	context?: Record<string, unknown>;
-}
-```
-*(See Core Concepts: [Error Handling](/core-concepts/error-handling))* 
+<TSDoc code={`import type { IError } from '@elsikora/cladi';
+export default IError`} />
 
-## Options Interfaces
-
-These interfaces define the configuration options for creating instances of the base implementations.
-
-### `IBaseContainerOptions`
-
-Options for `BaseContainer`.
-*Defined in: `src/infrastructure/interface/base/container-options.interface.ts`*
-
-```typescript copy
-export interface IBaseContainerOptions {
-	logger?: ILogger;
-}
-```
-
-### `IBaseRegistryOptions`
-
-Options for `BaseRegistry`.
-*Defined in: `src/infrastructure/interface/base/registry-options.interface.ts`*
-
-```typescript copy
-export interface IBaseRegistryOptions {
-	logger?: ILogger;
-}
-```
-
-### `IBaseFactoryOptions<T>`
-
-Options for `BaseFactory`.
-*Defined in: `src/infrastructure/interface/base/factory-options.interface.ts`*
-
-```typescript copy
-export interface IBaseFactoryOptions<T> {
-	logger?: ILogger;
-	registry: IRegistry<T>;
-	transformer?: (template: T) => T; // Optional function to transform template before caching/cloning
-}
-```
-
-### `IConsoleLoggerOptions`
-
-Options for `ConsoleLoggerService`.
-*Defined in: `src/infrastructure/interface/console-logger-options.interface.ts`*
-
-```typescript copy
-export interface IConsoleLoggerOptions {
-	level: ELoggerLogLevel; // Minimum level to log - See [ELoggerLogLevel](/api-reference/enums#eloggerloglevel)
-	source?: string; // Default source identifier for the logger instance
-}
-```
-
-### `ILoggerMethodOptions`
-
-Options passed to individual `ILogger` methods.
-*Defined in: `src/domain/interface/logger/method-options.interface.ts`*
-
-```typescript copy
-export interface ILoggerMethodOptions {
-	context?: Record<string, unknown>; // Additional data for this specific log entry
-	source?: string; // Overrides the logger's default source for this entry
-}
-```
-
-### `IBaseErrorOptions`
-
-Options for `BaseError` constructor.
-*Defined in: `src/infrastructure/interface/base/error-options.interface.ts`*
-
-```typescript copy
-export interface IBaseErrorOptions {
-	cause?: Error;
-	code: string;
-	context?: Record<string, unknown>;
-	source?: string; // e.g., "[AuthService]", "[UserRepository]"
-}
-```
-
-### `ICoreFactoryOptions`
-
-Options for the `CoreFactory` singleton.
-*Defined in: `src/infrastructure/interface/core-factory-options.interface.ts`*
-
-```typescript copy
-export interface ICoreFactoryOptions {
-	logger?: ILogger;
-}
-``` 
+*(See Core Concepts: [Error Handling](/docs/cladi/core-concepts/error-handling))*

--- a/docs/api-reference/page.mdx
+++ b/docs/api-reference/page.mdx
@@ -1,6 +1,10 @@
+---
+asIndexPage: true
+---
+
 # Overview
 
 This section provides detailed reference documentation for the public Enums and Interfaces exposed by the library.
 
-- **[Enums](/api-reference/enums)**: Constant values used within the library.
-- **[Interfaces](/api-reference/interfaces)**: Type definitions and contracts for core components and options. 
+- **[Enums](/docs/cladi/api-reference/enums)**: Constant values used within the library.
+- **[Interfaces](/docs/cladi/api-reference/interfaces)**: Type definitions and contracts for core components and options. 

--- a/docs/core-concepts/_meta.js
+++ b/docs/core-concepts/_meta.js
@@ -1,7 +1,6 @@
 export default {
-	container: "Dependency Injection (Container)",
+	container: "Container Pattern",
 	"error-handling": "Error Handling",
 	factory: "Factory Pattern",
-	index: "Overview",
 	registry: "Registry Pattern",
 };

--- a/docs/core-concepts/container/page.mdx
+++ b/docs/core-concepts/container/page.mdx
@@ -1,4 +1,6 @@
-# Dependency Injection (Container)
+import { unstable_TSDoc as TSDoc } from 'nextra/tsdoc'
+
+# Container Pattern
 
 The `Container` is the heart of the dependency injection (DI) system provided by `@elsikora/cladi`. DI is a fundamental design pattern that promotes loose coupling and testability by allowing components to receive their dependencies from an external source (the container) rather than creating them internally.
 
@@ -66,7 +68,7 @@ Think of the container as a central hub where you register all the building bloc
   ```
 
 - **Checking Existence (`has`)**: Verify if a token is registered before attempting retrieval.
-  ```typescript copy
+  ```typescript filename="src/check-existence.ts" copy
   declare const logger: ILogger;
   if (container.has(Tokens.SomeService)) {
     const service = container.get<SomeService>(Tokens.SomeService);
@@ -77,14 +79,14 @@ Think of the container as a central hub where you register all the building bloc
   ```
 
 - **Unregistration (`unregister`/`unregisterMany`)**: Remove dependencies, useful in testing or dynamic scenarios (less common in typical application flow).
-  ```typescript copy
+  ```typescript filename="src/unregister-example.ts" copy
   declare const logger: ILogger;
   container.unregister(Tokens.SomeService);
   logger.debug(`Has SomeService after unregister: ${container.has(Tokens.SomeService)}`); // Logs: false
   ```
 
 - **Clearing (`clear`)**: Remove all registered dependencies, primarily for test environment teardown to ensure test isolation.
-  ```typescript copy
+  ```typescript filename="src/clear-example.ts" copy
   declare const logger: ILogger;
   container.clear();
   logger.debug(`Has Logger after clear: ${container.has(EServiceToken.LOGGER)}`); // Logs: false
@@ -100,4 +102,9 @@ Think of the container as a central hub where you register all the building bloc
 
 - **`IContainer` (Interface)**: Located in `src/domain/interface/container.interface.ts`. Defines the essential methods (`register`, `get`, `has`, etc.) that any container must implement.
 - **`BaseContainer` (Class)**: Located in `src/infrastructure/class/base/container.class.ts`. The default, concrete implementation provided by the library. It includes built-in logging for container operations (if a logger is provided) to aid debugging.
-- **`createContainer` (Utility)**: Exported from the library root (`import { createContainer } from '@elsikora/cladi';`). A convenient factory function to instantiate `BaseContainer`. It accepts `IBaseContainerOptions`, primarily used for injecting a logger into the container itself. 
+- **`createContainer` (Utility)**: Exported from the library root (`import { createContainer } from '@elsikora/cladi';`). A convenient factory function to instantiate `BaseContainer`. It accepts `IBaseContainerOptions`, primarily used for injecting a logger into the container itself.
+
+### Base Implementation Options (`IBaseContainerOptions`)
+
+<TSDoc code={`import type { IBaseContainerOptions } from '@elsikora/cladi';
+export default IBaseContainerOptions`} />

--- a/docs/core-concepts/error-handling/page.mdx
+++ b/docs/core-concepts/error-handling/page.mdx
@@ -1,3 +1,5 @@
+import { unstable_TSDoc as TSDoc } from 'nextra/tsdoc'
+
 # Error Handling
 
 `@elsikora/cladi` promotes a structured approach to error handling using the `IError` interface and the `BaseError` class. This provides more context and allows for better programmatic handling compared to standard JavaScript `Error` objects.
@@ -6,7 +8,7 @@
 
 This is the core contract for errors within the library. It extends the built-in `Error` and adds fields crucial for robust error management:
 
-```typescript copy
+```typescript filename="src/domain/interface/error.interface.ts" copy
 // Located in: src/domain/interface/error.interface.ts
 export interface IError extends Error {
   /**
@@ -132,4 +134,9 @@ async function processItem(id: string) {
 
 - **`IError` (Interface)**: Located in `src/domain/interface/error.interface.ts`.
 - **`BaseError` (Class)**: Located in `src/infrastructure/class/base/error.class.ts`. Implements `IError` and captures stack traces.
-- **`IBaseErrorOptions` (Interface)**: Located in `src/infrastructure/interface/base/error-options.interface.ts`. Defines the options object passed to the `BaseError`
+- **`IBaseErrorOptions` (Interface)**: Located in `src/infrastructure/interface/base/error-options.interface.ts`. Defines the options object passed to the `BaseError` constructor.
+
+### Base Implementation Options (`IBaseErrorOptions`)
+
+<TSDoc code={`import { BaseContainer } from '@elsikora/cladi';
+export default BaseContainer`} />

--- a/docs/core-concepts/factory/page.mdx
+++ b/docs/core-concepts/factory/page.mdx
@@ -1,13 +1,15 @@
+import { unstable_TSDoc as TSDoc } from 'nextra/tsdoc'
+
 # Factory Pattern
 
-The `Factory` pattern, implemented via `IFactory` and `BaseFactory`, provides a standardized way to create instances of objects based on named templates stored in a [`Registry`](/core-concepts/registry).
+The `Factory` pattern, implemented via `IFactory` and `BaseFactory`, provides a standardized way to create instances of objects based on named templates stored in a [`Registry`](/docs/cladi/core-concepts/registry).
 
 Instead of scattering `new MyObject(...)` calls throughout your code, you ask the factory to `create('objectName')`.
 This centralizes creation logic and makes it easy to switch out implementations or configurations.
 
 ## Key Features & Examples
 
-- **Creation (`create`)**: The core method. It takes a `name`, looks up the corresponding template object in its associated [`Registry`](/core-concepts/registry), clones it (by default using `structuredClone`), potentially transforms it, caches it, and returns the final instance.
+- **Creation (`create`)**: The core method. It takes a `name`, looks up the corresponding template object in its associated [`Registry`](/docs/cladi/core-concepts/registry), clones it (by default using `structuredClone`), potentially transforms it, caches it, and returns the final instance.
 
   ```typescript filename="src/user-factory.ts" copy
   import { createFactory, createRegistry, type IFactory, type IRegistry } from '@elsikora/cladi';
@@ -62,7 +64,7 @@ This centralizes creation logic and makes it easy to switch out implementations 
 
 - **Optional Transformation (`transformer`)**: You can provide a function (`IBaseFactoryOptions.transformer`) that takes the template from the registry and returns a modified version *before* it's cached and cloned by the factory. This is useful for applying defaults, adding dynamic properties, or performing complex setup.
 
-  ```typescript copy
+  ```typescript filename="src/transforming-factory.ts" copy
   // ... registry setup as before ...
 
   // Assume userRegistry is declared and populated
@@ -85,17 +87,22 @@ This centralizes creation logic and makes it easy to switch out implementations 
 
 - **Caching (Internal)**: The `BaseFactory` caches the *first transformed template* for each name. Subsequent calls to `create` for the same name will `structuredClone` this cached template, avoiding repeated lookups and transformations.
 
-- **Cache Clearing (`clearCache`)**: If the underlying [`Registry`](/core-concepts/registry) changes, you *must* call `factory.clearCache(name?)` to remove the factory's cached template(s) and force it to re-fetch (and re-transform) from the registry on the next `create` call. If `name` is omitted, the entire factory cache is cleared.
+- **Cache Clearing (`clearCache`)**: If the underlying [`Registry`](/docs/cladi/core-concepts/registry) changes, you *must* call `factory.clearCache(name?)` to remove the factory's cached template(s) and force it to re-fetch (and re-transform) from the registry on the next `create` call. If `name` is omitted, the entire factory cache is cleared.
 
 ## Purpose & Use Cases
 
 - **Decouple Object Creation**: Hides the complexity of creating objects (`new ...`, setting defaults, etc.) behind a simple `create(name)` interface.
 - **Manage Instance Variations**: Easily create different pre-configured instances of the same base object type (like user profiles, database connections, API clients).
 - **Enforce Consistency**: Ensures objects are created according to the defined templates in the registry.
-- **Combine with DI**: Factories themselves can be registered in the [`Container`](/core-concepts/container) to provide on-demand creation of specific object types throughout the application.
+- **Combine with DI**: Factories themselves can be registered in the [`Container`](/docs/cladi/core-concepts/container) to provide on-demand creation of specific object types throughout the application.
 
 ## Core Implementation
 
 - **`IFactory<T>` (Interface)**: Located in `src/domain/interface/factory.interface.ts`. Defines the `create` method and `getRegistry`.
 - **`BaseFactory<T>` (Class)**: Located in `src/infrastructure/class/base/factory.class.ts`. The default implementation using an associated `Registry`, with template caching, cloning, and optional transformation.
-- **`createFactory<T>` (Utility)**: Exported from the library root. A convenient function to instantiate `BaseFactory`, requiring `IBaseFactoryOptions` (which must include a `registry`). 
+- **`createFactory<T>` (Utility)**: Exported from the library root. A convenient function to instantiate `BaseFactory`, requiring `IBaseFactoryOptions` (which must include a `registry`).
+
+### Base Implementation Options (`IBaseFactoryOptions`)
+
+<TSDoc code={`import type { IBaseFactoryOptions } from '@elsikora/cladi';
+export default IBaseFactoryOptions`} /> 

--- a/docs/core-concepts/page.mdx
+++ b/docs/core-concepts/page.mdx
@@ -1,9 +1,13 @@
+---
+asIndexPage: true
+---
+
 # Overview
 
 This section delves into the fundamental design patterns and concepts employed within the library.
 Understanding these concepts is key to effectively using the provided utilities.
 
-- **[Dependency Injection (Container)](/core-concepts/container)**: Learn how the `Container` manages dependencies and promotes loose coupling.
-- **[Registry Pattern](/core-concepts/registry)**: Discover how the `Registry` is used to store and retrieve named templates or configurations.
-- **[Factory Pattern](/core-concepts/factory)**: See how the `Factory` utilizes the `Registry` to create instances of objects.
-- **[Error Handling](/core-concepts/error-handling)**: Understand the standardized `Error` structure used throughout the library. 
+- **[Dependency Injection (Container)](/docs/cladi/core-concepts/container)**: Learn how the `Container` manages dependencies and promotes loose coupling.
+- **[Registry Pattern](/docs/cladi/core-concepts/registry)**: Discover how the `Registry` is used to store and retrieve named templates or configurations.
+- **[Factory Pattern](/docs/cladi/core-concepts/factory)**: See how the `Factory` utilizes the `Registry` to create instances of objects.
+- **[Error Handling](/docs/cladi/core-concepts/error-handling)**: Understand the standardized `Error` structure used throughout the library. 

--- a/docs/core-concepts/registry/page.mdx
+++ b/docs/core-concepts/registry/page.mdx
@@ -1,7 +1,9 @@
+import { unstable_TSDoc as TSDoc } from 'nextra/tsdoc'
+
 # Registry Pattern
 
 The `Registry` pattern, implemented by `IRegistry` and `BaseRegistry`, provides a way to store and retrieve objects or configuration templates using a simple string name.
-It's often used as the data source for a [Factory](/core-concepts/factory).
+It's often used as the data source for a [Factory](/docs/cladi/core-concepts/factory).
 
 Imagine needing different sets of configuration for different environments (dev, staging, prod) or different types of resources (small server, large server). A Registry is ideal for managing these named variations.
 
@@ -45,7 +47,7 @@ Imagine needing different sets of configuration for different environments (dev,
 
 - **Retrieval (`get`/`getMany`/`getAll`)**: Fetch items by their registered name(s). `getAll` retrieves all registered items.
 
-  ```typescript copy
+  ```typescript filename="src/retrieve-configs.ts" copy
   // Assuming registry from previous example
 
   const devConfig = registry.get("standard-dev");
@@ -62,20 +64,20 @@ Imagine needing different sets of configuration for different environments (dev,
   ```
 
 - **Checking Existence (`has`)**: Quickly check if a name is registered without retrieving the object.
-  ```typescript copy
+  ```typescript filename="src/check-config.ts" copy
   if (registry.has("high-mem-prod")) {
     console.log("Production configuration is available.");
   }
   ```
 
 - **Unregistration (`unregister`/`unregisterMany`)**: Remove items by name.
-  ```typescript copy
+  ```typescript filename="src/unregister-config.ts" copy
   registry.unregister("standard-dev");
   console.log(`Registry contains 'standard-dev' after unregister: ${registry.has("standard-dev")}`); // false
   ```
 
 - **Clearing (`clear`)**: Empty the entire registry.
-  ```typescript copy
+  ```typescript filename="src/clear-registry.ts" copy
   registry.clear();
   console.log(`Total configs after clear: ${registry.getAll().length}`); // 0
   ```
@@ -86,10 +88,15 @@ Imagine needing different sets of configuration for different environments (dev,
 
 - **Managing Variations**: Store different versions or configurations of an object (e.g., environment settings, feature flag states, UI themes, resource definitions).
 - **Decoupling Definitions**: Separates the *definition* of these variations from the code that *uses* them.
-- **Data Source for Factories**: Provide the named templates that a [Factory](/core-concepts/factory) will use to create actual instances.
+- **Data Source for Factories**: Provide the named templates that a [Factory](/docs/cladi/core-concepts/factory) will use to create actual instances.
 
 ## Core Implementation
 
 - **`IRegistry<T>` (Interface)**: Located in `src/domain/interface/registry.interface.ts`. Defines the contract. The generic type `T` is constrained to be an object with at least a `name: string` property (`T extends { name: string }`).
 - **`BaseRegistry<T>` (Class)**: Located in `src/infrastructure/class/base/registry.class.ts`. The default implementation, featuring internal caching and optional logging.
-- **`createRegistry<T>` (Utility)**: Exported from the library root. A convenient function to instantiate `BaseRegistry`, accepting `IBaseRegistryOptions` (primarily for passing a logger). 
+- **`createRegistry<T>` (Utility)**: Exported from the library root. A convenient function to instantiate `BaseRegistry`, accepting `IBaseRegistryOptions` (primarily for passing a logger).
+
+### Base Implementation Options (`IBaseRegistryOptions`)
+
+<TSDoc code={`import type { IBaseRegistryOptions } from '@elsikora/cladi';
+export default IBaseRegistryOptions`} /> 

--- a/docs/getting-started/page.mdx
+++ b/docs/getting-started/page.mdx
@@ -1,25 +1,39 @@
+import { Tabs } from 'nextra/components'
+
 # Getting Started
 
 This guide will walk you through the basic setup and usage of the core utilities.
 
 ## Installation
 
-```bash copy
-# Using npm
-npm install @elsikora/cladi
-
-# Using yarn
-yarn add @elsikora/cladi
-
-# Using pnpm
-pnpm add @elsikora/cladi
-```
+<Tabs items={['npm', 'yarn', 'pnpm', 'bun']} storageKey="cladi-install-tabs">
+  <Tabs.Tab>
+    ```bash copy
+    npm install @elsikora/cladi
+    ```
+  </Tabs.Tab>
+  <Tabs.Tab>
+    ```bash copy
+    yarn add @elsikora/cladi
+    ```
+  </Tabs.Tab>
+  <Tabs.Tab>
+    ```bash copy
+    pnpm add @elsikora/cladi
+    ```
+  </Tabs.Tab>
+  <Tabs.Tab>
+    ```bash copy
+    bun install @elsikora/cladi
+    ```
+  </Tabs.Tab>
+</Tabs>
 
 ## Basic Usage
 
 Here's a simple example of creating and using the core components:
 
-```typescript copy
+```typescript filename="basic-usage.ts" copy
 import {
 	createContainer,
 	createRegistry,

--- a/docs/page.mdx
+++ b/docs/page.mdx
@@ -1,3 +1,8 @@
+---
+title: Cladi
+asIndexPage: true
+---
+
 # Introduction
 
 Welcome to the documentation for the ClaDI - TypeScript Core Utilities library.

--- a/docs/services/_meta.js
+++ b/docs/services/_meta.js
@@ -1,4 +1,3 @@
 export default {
-	index: "Overview",
 	logging: "Logging Service",
 };

--- a/docs/services/logging/page.mdx
+++ b/docs/services/logging/page.mdx
@@ -1,3 +1,5 @@
+import { unstable_TSDoc as TSDoc } from 'nextra/tsdoc'
+
 # Logging Service
 
 Effective logging is crucial for understanding application behavior and debugging issues. `@elsikora/cladi` provides a flexible logging system through the `ILogger` interface and a ready-to-use `ConsoleLoggerService`.
@@ -6,7 +8,7 @@ Effective logging is crucial for understanding application behavior and debuggin
 
 This defines the standard contract for any logger implementation. It includes methods for different severity levels:
 
-```typescript copy
+```typescript filename="src/domain/interface/logger/interface.ts" copy
 // Located in: src/domain/interface/logger/interface.ts
 export interface ILogger {
   debug(message: string, options?: ILoggerMethodOptions): void;
@@ -28,6 +30,13 @@ export interface ILoggerMethodOptions {
 - **Levels**: `trace` (most verbose), `debug`, `info`, `warn`, `error` (least verbose).
 - **Options**: Allow passing extra `context` (like user ID, request details) and overriding the `source` identifier for specific messages.
 
+### `ILoggerMethodOptions`
+
+These options can be passed to individual logger methods (`.debug()`, `.info()`, etc.) to provide additional context or override the default source for that specific log entry.
+
+<TSDoc code={`import type { ILoggerMethodOptions } from '@elsikora/cladi';
+export default ILoggerMethodOptions`} />
+
 ## `ConsoleLoggerService`
 
 This is the default implementation provided, suitable for most Node.js and browser environments. It logs messages to the standard console (`console.debug`, `console.info`, etc.).
@@ -39,6 +48,13 @@ This is the default implementation provided, suitable for most Node.js and brows
 - **Level Display**: Clearly shows the log level (e.g., `[INFO]`).
 - **Source Identification**: Includes a source tag (e.g., `[AuthService]`, `[App -> DataProcessor]`) for easier filtering and context.
 - **Structured Context**: Appends the `context` object as a formatted JSON string.
+
+### Constructor Options (`IConsoleLoggerOptions`)
+
+These options are passed to the `createLogger` utility or the `ConsoleLoggerService` constructor to configure the logger instance.
+
+<TSDoc code={`import type { IConsoleLoggerOptions } from '@elsikora/cladi';
+export default IConsoleLoggerOptions`} />
 
 **Example Usage:**
 
@@ -85,7 +101,7 @@ logger.trace("Detailed trace message - only shown if level is TRACE"); // Won't 
 
 **Output Example (Conceptual):**
 
-```text
+```text filename="console-output.log" copy
 [2023-10-27T10:00:00.000Z] INFO: [MainApp] Application setup initiated.
 [2023-10-27T10:00:00.001Z] DEBUG: [MainApp -> UserProcessor] Starting user processing {"userId":123}
 [2023-10-27T10:00:00.002Z] INFO: [MainApp -> UserProcessor] User processed successfully {"userId":123,"status":"completed"}
@@ -97,7 +113,7 @@ logger.trace("Detailed trace message - only shown if level is TRACE"); // Won't 
 
 The easiest way to get a `ConsoleLoggerService` instance is via the `createLogger` helper:
 
-```typescript copy
+```typescript filename="src/create-logger-examples.ts" copy
 import { createLogger, ELoggerLogLevel } from '@elsikora/cladi';
 
 // Logger with default level (INFO) and no source
@@ -112,6 +128,4 @@ const debugLogger = createLogger({
 
 ## Integrating with Dependency Injection
 
-Typically, you create a logger instance early in your application setup and register it with the [`Container`](/core-concepts/container) using `EServiceToken.LOGGER`. Other services can then receive the logger via constructor injection.
-
-```
+Typically, you create a logger instance early in your application setup and register it with the [`Container`](/docs/cladi/core-concepts/container) using `EServiceToken.LOGGER`. Other services can then receive the logger via constructor injection.

--- a/docs/services/page.mdx
+++ b/docs/services/page.mdx
@@ -1,6 +1,10 @@
+---
+asIndexPage: true
+---
+
 # Overview
 
 This section describes the services provided by the library.
 Services typically encapsulate reusable functionality or interact with external systems.
 
-- **[Logging Service](/services/logging)**: Learn about the standard logging interface and the provided console implementation.
+- **[Logging Service](/docs/cladi/services/logging)**: Learn about the standard logging interface and the provided console implementation.

--- a/docs/utilities/_meta.js
+++ b/docs/utilities/_meta.js
@@ -1,4 +1,3 @@
 export default {
 	"creation-helpers": "Creation Helpers",
-	index: "Overview",
 };

--- a/docs/utilities/creation-helpers/page.mdx
+++ b/docs/utilities/creation-helpers/page.mdx
@@ -1,3 +1,5 @@
+import { unstable_TSDoc as TSDoc } from 'nextra/tsdoc'
+
 # Creation Helpers
 
 `@elsikora/cladi` provides convenient utility functions (exported from the root of the package) to quickly instantiate the default implementations of the core components.
@@ -27,7 +29,11 @@ const container2: IContainer = createContainer(containerOptions);
 
 - **Purpose**: Quickly get a dependency injection container ready for registrations.
 - **Options (`IBaseContainerOptions`)**: Allows injecting a logger to monitor the container's own actions (register, get, etc.).
-- **See Also**: [Core Concepts: Container](/core-concepts/container)
+
+<TSDoc code={`import type { IBaseContainerOptions } from '@elsikora/cladi';
+export default IBaseContainerOptions`} />
+
+**See Also**: [Core Concepts: Container](/docs/cladi/core-concepts/container)
 
 ## `createRegistry<T>`
 
@@ -58,7 +64,11 @@ const registry2: IRegistry<ServiceEndpoint> = createRegistry<ServiceEndpoint>(re
 
 - **Purpose**: Set up a named collection for storing configuration templates or object prototypes.
 - **Options (`IBaseRegistryOptions`)**: Allows injecting a logger for monitoring registry operations.
-- **See Also**: [Core Concepts: Registry](/core-concepts/registry)
+
+<TSDoc code={`import type { IBaseRegistryOptions } from '@elsikora/cladi';
+export default IBaseRegistryOptions`} />
+
+**See Also**: [Core Concepts: Registry](/docs/cladi/core-concepts/registry)
 
 ## `createFactory<T>`
 
@@ -87,7 +97,11 @@ const factory: IFactory<ServiceEndpoint> = createFactory<ServiceEndpoint>(factor
 
 - **Purpose**: Create an object factory that uses a registry as its source for templates.
 - **Options (`IBaseFactoryOptions`)**: Requires `registry`. Optionally takes a `logger` and a `transformer` function.
-- **See Also**: [Core Concepts: Factory](/core-concepts/factory)
+
+<TSDoc code={`import type { IBaseFactoryOptions } from '@elsikora/cladi';
+export default IBaseFactoryOptions`} />
+
+**See Also**: [Core Concepts: Factory](/docs/cladi/core-concepts/factory)
 
 ## `createLogger`
 
@@ -111,4 +125,8 @@ customLogger.debug("Debug message from MyModule.");
 
 - **Purpose**: Quickly get a standard console logger instance.
 - **Options (`IConsoleLoggerOptions`)**: Allows setting the minimum `level` and a default `source` identifier.
-- **See Also**: [Services: Logging](/services/logging) 
+
+<TSDoc code={`import type { IConsoleLoggerOptions } from '@elsikora/cladi';
+export default IConsoleLoggerOptions`} />
+
+**See Also**: [Services: Logging](/docs/cladi/services/logging) 

--- a/docs/utilities/page.mdx
+++ b/docs/utilities/page.mdx
@@ -1,5 +1,8 @@
+---
+asIndexPage: true
+---
 # Overview
 
 This section covers utility functions provided by the library to simplify common tasks.
 
-- **[Creation Helpers](/utilities/creation-helpers)**: Functions to easily instantiate core components like Containers, Registries, Factories, and Loggers. 
+- **[Creation Helpers](/docs/cladi/utilities/creation-helpers)**: Functions to easily instantiate core components like Containers, Registries, Factories, and Loggers. 

--- a/src/domain/interface/container.interface.ts
+++ b/src/domain/interface/container.interface.ts
@@ -1,6 +1,7 @@
 /* eslint-disable @elsikora/typescript/no-unnecessary-type-parameters */
 /**
  * Simple dependency injection container interface.
+ * @see {@link https://elsikora.com/docs/cladi/core-concepts/container}
  */
 export interface IContainer {
 	/**

--- a/src/domain/interface/error.interface.ts
+++ b/src/domain/interface/error.interface.ts
@@ -1,5 +1,6 @@
 /**
  * Standard error interface for all application errors.
+ * @see {@link https://elsikora.com/docs/cladi/core-concepts/error-handling}
  */
 export interface IError extends Error {
 	/**

--- a/src/domain/interface/factory.interface.ts
+++ b/src/domain/interface/factory.interface.ts
@@ -3,6 +3,7 @@ import type { IRegistry } from "./registry.interface";
 /**
  * Generic factory interface for creating items by name.
  * @template T The type of items created by the factory.
+ * @see {@link https://elsikora.com/docs/cladi/core-concepts/factory}
  */
 export interface IFactory<T> {
 	/**

--- a/src/domain/interface/logger/interface.ts
+++ b/src/domain/interface/logger/interface.ts
@@ -2,6 +2,7 @@ import type { ILoggerMethodOptions } from "./method-options.interface";
 
 /**
  * Logger interface.
+ * @see {@link https://elsikora.com/docs/cladi/services/logging}
  */
 export interface ILogger {
 	/**

--- a/src/domain/interface/logger/method-options.interface.ts
+++ b/src/domain/interface/logger/method-options.interface.ts
@@ -1,5 +1,6 @@
 /**
  * Log options interface.
+ * @see {@link https://elsikora.com/docs/cladi/services/logging}
  */
 export interface ILoggerMethodOptions {
 	/**

--- a/src/domain/interface/registry.interface.ts
+++ b/src/domain/interface/registry.interface.ts
@@ -1,6 +1,7 @@
 /**
  * Generic registry interface for managing items by name.
  * @template T The type of items stored in the registry.
+ * @see {@link https://elsikora.com/docs/cladi/core-concepts/registry}
  */
 export interface IRegistry<T> {
 	/**

--- a/src/infrastructure/class/base/container.class.ts
+++ b/src/infrastructure/class/base/container.class.ts
@@ -8,6 +8,7 @@ import { BaseError } from "./error.class";
 
 /**
  * Simple dependency injection container implementation.
+ * @see {@link https://elsikora.com/docs/cladi/core-concepts/container}
  */
 export class BaseContainer implements IContainer {
 	private readonly DEPENDENCIES: Map<symbol, unknown>;

--- a/src/infrastructure/class/base/error.class.ts
+++ b/src/infrastructure/class/base/error.class.ts
@@ -3,6 +3,7 @@ import type { IBaseErrorOptions } from "@infrastructure/interface/base";
 
 /**
  * Base error class.
+ * @see {@link https://elsikora.com/docs/cladi/core-concepts/error-handling}
  */
 export class BaseError extends Error implements IError {
 	public readonly CAUSE?: Error;

--- a/src/infrastructure/class/base/factory.class.ts
+++ b/src/infrastructure/class/base/factory.class.ts
@@ -10,6 +10,7 @@ import { BaseError } from "./error.class";
 /**
  * Generic factory implementation that creates items by name using a registry as data source.
  * @template T The type of items created by the factory.
+ * @see {@link https://elsikora.com/docs/cladi/core-concepts/factory}
  */
 export class BaseFactory<T> implements IFactory<T> {
 	private readonly CACHE: Map<string, T>;

--- a/src/infrastructure/class/base/registry.class.ts
+++ b/src/infrastructure/class/base/registry.class.ts
@@ -9,6 +9,7 @@ import { BaseError } from "./error.class";
 /**
  * Generic registry implementation that stores items by name.
  * @template T The type of items stored in the registry.
+ * @see {@link https://elsikora.com/docs/cladi/core-concepts/registry}
  */
 export class BaseRegistry<T extends { name: string }> implements IRegistry<T> {
 	private readonly CACHE: Map<string, Array<T>>;

--- a/src/infrastructure/factory/core.factory.ts
+++ b/src/infrastructure/factory/core.factory.ts
@@ -7,6 +7,7 @@ import { ConsoleLoggerService } from "@infrastructure/service";
 /**
  * Factory for creating infrastructure components.
  * Provides methods to create instances of Registry, Factory, Container, and Logger.
+ * @see {@link https://elsikora.com/docs/cladi/core-concepts/factory} for more details on factories.
  */
 export class CoreFactory {
 	private static instance: CoreFactory;
@@ -16,6 +17,7 @@ export class CoreFactory {
 	/**
 	 * Creates a new infrastructure factory.
 	 * @param {ICoreFactoryOptions} options - The options to use for the factory.
+	 * @see {@link https://elsikora.com/docs/cladi/core-concepts/factory}
 	 */
 	constructor(options: ICoreFactoryOptions) {
 		this.LOGGER = options.logger ?? new ConsoleLoggerService();
@@ -25,6 +27,7 @@ export class CoreFactory {
 	 * Gets the singleton instance of the InfrastructureFactory.
 	 * @param {ICoreFactoryOptions} options - The options to use for the factory.
 	 * @returns {CoreFactory} The singleton instance.
+	 * @see {@link https://elsikora.com/docs/cladi/core-concepts/factory}
 	 */
 	public static getInstance(options: ICoreFactoryOptions): CoreFactory {
 		if (!CoreFactory.instance) {
@@ -38,6 +41,7 @@ export class CoreFactory {
 	 * Creates a new container instance.
 	 * @param {IBaseContainerOptions} options - The options to use for the container.
 	 * @returns {IContainer} A new container instance.
+	 * @see {@link https://elsikora.com/docs/cladi/core-concepts/container}
 	 */
 	public createContainer(options: IBaseContainerOptions): IContainer {
 		this.LOGGER?.debug("Creating new container instance", { source: "InfrastructureFactory" });
@@ -54,6 +58,7 @@ export class CoreFactory {
 	 * @template T The type of items created by the factory.
 	 * @param {IBaseFactoryOptions<T>} options Factory creation options.
 	 * @returns {IFactory<T>} A new factory instance.
+	 * @see {@link https://elsikora.com/docs/cladi/core-concepts/factory}
 	 */
 	public createFactory<T>(options: IBaseFactoryOptions<T>): IFactory<T> {
 		this.LOGGER?.debug("Creating new factory instance", { source: "InfrastructureFactory" });
@@ -69,6 +74,7 @@ export class CoreFactory {
 	 * Creates a new logger instance.
 	 * @param {IConsoleLoggerOptions} options - The options to use for the logger.
 	 * @returns {ILogger} A new logger instance.
+	 * @see {@link https://elsikora.com/docs/cladi/services/logging}
 	 */
 	public createLogger(options: IConsoleLoggerOptions): ILogger {
 		this.LOGGER?.debug("Creating new logger instance", {
@@ -88,6 +94,7 @@ export class CoreFactory {
 	 * @template T The type of items stored in the registry (must have a name property).
 	 * @param {IBaseRegistryOptions} options - The options to use for the registry.
 	 * @returns {IRegistry<T>} A new registry instance.
+	 * @see {@link https://elsikora.com/docs/cladi/core-concepts/registry}
 	 */
 	public createRegistry<T extends { name: string }>(options: IBaseRegistryOptions): IRegistry<T> {
 		this.LOGGER?.debug("Creating new registry instance", { source: "InfrastructureFactory" });

--- a/src/infrastructure/interface/base/container-options.interface.ts
+++ b/src/infrastructure/interface/base/container-options.interface.ts
@@ -2,10 +2,12 @@ import type { ILogger } from "@domain/interface";
 
 /**
  * The options for the base container.
+ * @see {@link https://elsikora.com/docs/cladi/core-concepts/container} for more details.
  */
 export interface IBaseContainerOptions {
 	/**
 	 * The logger to use for the container.
+	 * @default new ConsoleLoggerService()
 	 */
 	logger?: ILogger;
 }

--- a/src/infrastructure/interface/base/error-options.interface.ts
+++ b/src/infrastructure/interface/base/error-options.interface.ts
@@ -1,5 +1,6 @@
 /**
  * Base options interface.
+ * @see {@link https://elsikora.com/docs/cladi/core-concepts/error-handling} for more details.
  */
 export interface IBaseErrorOptions {
 	/**

--- a/src/infrastructure/interface/base/factory-options.interface.ts
+++ b/src/infrastructure/interface/base/factory-options.interface.ts
@@ -4,10 +4,12 @@ import type { ILogger } from "@domain/interface/logger/interface";
 /**
  * Base factory creation options.
  * @template T The type of items in the registry and created by the factory.
+ * @see {@link https://elsikora.com/docs/cladi/core-concepts/factory} for more details.
  */
 export interface IBaseFactoryOptions<T> {
 	/**
 	 * The logger to use for logging.
+	 * @default new ConsoleLoggerService()
 	 */
 	logger?: ILogger;
 

--- a/src/infrastructure/interface/base/registry-options.interface.ts
+++ b/src/infrastructure/interface/base/registry-options.interface.ts
@@ -2,10 +2,12 @@ import type { ILogger } from "@domain/interface/logger/interface";
 
 /**
  * Base registry creation options.
+ * @see {@link https://elsikora.com/docs/cladi/core-concepts/registry} for more details.
  */
 export interface IBaseRegistryOptions {
 	/**
 	 * The logger to use for logging.
+	 * @default new ConsoleLoggerService()
 	 */
 	logger?: ILogger;
 }

--- a/src/infrastructure/interface/console-logger-options.interface.ts
+++ b/src/infrastructure/interface/console-logger-options.interface.ts
@@ -2,6 +2,7 @@ import type { ELoggerLogLevel } from "@domain/enum";
 
 /**
  * The options for the console logger.
+ * @see {@link https://elsikora.com/docs/cladi/services/logging} for more details on logging options.
  */
 export interface IConsoleLoggerOptions {
 	/**

--- a/src/infrastructure/interface/core-factory-options.interface.ts
+++ b/src/infrastructure/interface/core-factory-options.interface.ts
@@ -2,10 +2,12 @@ import type { ILogger } from "@domain/interface";
 
 /**
  * Options for the CoreFactory.
+ * @see {@link https://elsikora.com/docs/cladi/core-concepts/factory} for more details.
  */
 export interface ICoreFactoryOptions {
 	/**
 	 * The logger to use for the factory.
+	 * @default new ConsoleLoggerService()
 	 */
 	logger?: ILogger;
 }

--- a/src/infrastructure/service/console-logger.service.ts
+++ b/src/infrastructure/service/console-logger.service.ts
@@ -6,6 +6,7 @@ import { CONSOLE_LOGGER_DEFAULT_OPTIONS } from "@infrastructure/constant";
 
 /**
  * Console logger implementation.
+ * @see {@link https://elsikora.com/docs/cladi/services/logging}
  */
 export class ConsoleLoggerService implements ILogger {
 	/**
@@ -20,7 +21,8 @@ export class ConsoleLoggerService implements ILogger {
 
 	/**
 	 * Create a new console logger.
-	 * @param {IConsoleLoggerOptions} options - The options to use for the logger.
+	 * @param {IConsoleLoggerOptions} [options] - The options to use for the logger.
+	 * @default
 	 */
 	constructor(options: IConsoleLoggerOptions = CONSOLE_LOGGER_DEFAULT_OPTIONS) {
 		this.LEVEL = options.level;

--- a/src/presentation/utility/create/container.utility.ts
+++ b/src/presentation/utility/create/container.utility.ts
@@ -6,6 +6,7 @@ import { BaseContainer, type IBaseContainerOptions } from "@infrastructure/index
  * Creates a new container instance.
  * @param {IBaseContainerOptions} options - The options to use for the container.
  * @returns {IContainer} A new container instance.
+ * @see {@link https://elsikora.com/docs/cladi/core-concepts/container} for more information on containers.
  */
 export function createContainer(options: IBaseContainerOptions): IContainer {
 	return new BaseContainer(options);

--- a/src/presentation/utility/create/factory.utility.ts
+++ b/src/presentation/utility/create/factory.utility.ts
@@ -8,6 +8,7 @@ import { BaseFactory } from "@infrastructure/index";
  * @param {IBaseFactoryOptions<T>} options - The options to use for the factory.
  * @returns {IFactory<T>} A new factory instance.
  * @template T The type of items created by the factory.
+ * @see {@link https://elsikora.com/docs/cladi/core-concepts/factory} for more information on factories.
  */
 export function createFactory<T>(options: IBaseFactoryOptions<T>): IFactory<T> {
 	return new BaseFactory<T>(options);

--- a/src/presentation/utility/create/logger.utility.ts
+++ b/src/presentation/utility/create/logger.utility.ts
@@ -4,8 +4,10 @@ import { CONSOLE_LOGGER_DEFAULT_OPTIONS, ConsoleLoggerService, type IConsoleLogg
 
 /**
  * Creates a new logger instance.
- * @param {IConsoleLoggerOptions} options - The options to use for the logger.
+ * @param {IConsoleLoggerOptions} [options] - The options to use for the logger.
+ * @default
  * @returns {ILogger} A new logger instance.
+ * @see {@link https://elsikora.com/docs/cladi/services/logging} for more information on the logging service.
  */
 export function createLogger(options: IConsoleLoggerOptions = CONSOLE_LOGGER_DEFAULT_OPTIONS): ILogger {
 	return new ConsoleLoggerService(options);

--- a/src/presentation/utility/create/registry.utility.ts
+++ b/src/presentation/utility/create/registry.utility.ts
@@ -8,6 +8,7 @@ import { BaseRegistry } from "@infrastructure/index";
  * @param {IBaseRegistryOptions} options - The options to use for the registry.
  * @returns {IRegistry<T>} A new registry instance.
  * @template T The type of items stored in the registry.
+ * @see {@link https://elsikora.com/docs/cladi/core-concepts/registry} for more information on registries.
  */
 export function createRegistry<T extends { name: string }>(options: IBaseRegistryOptions): IRegistry<T> {
 	return new BaseRegistry<T>(options);


### PR DESCRIPTION
Enhanced documentation to work with the Nextra documentation framework. Changes include:

- Updated file structure for Nextra compatibility
- Added TSDoc component integration for API references
- Fixed internal links to use proper prefixes
- Improved formatting with code filename annotations
- Added JSDoc links back to documentation in source code
- Reorganized navigation structure in _meta.js files
- Added proper index page markers for documentation sections.