### PR TITLE
fix(docs): clean target directory before copying docs and fix tsdoc r…

### DIFF
--- a/.github/workflows/mirror-docs-to-docviewer.yml
+++ b/.github/workflows/mirror-docs-to-docviewer.yml
@@ -66,6 +66,12 @@ jobs:
           git checkout -b "$BRANCH_NAME"
 
           TARGET_DIR="src/app/docs/${{ steps.vars.outputs.KEBAB_CASE_REPO_NAME }}"
+
+          if [ -d "$TARGET_DIR" ]; then
+            echo "Cleaning target directory: $TARGET_DIR"
+            rm -rf "$TARGET_DIR"
+          fi
+
           mkdir -p "$TARGET_DIR"
 
           cp -r ../source/docs/* "$TARGET_DIR/"

--- a/docs/core-concepts/error-handling/page.mdx
+++ b/docs/core-concepts/error-handling/page.mdx
@@ -138,5 +138,5 @@ async function processItem(id: string) {
 
 ### Base Implementation Options (`IBaseErrorOptions`)
 
-<TSDoc code={`import { BaseContainer } from '@elsikora/cladi';
-export default BaseContainer`} />
+<TSDoc code={`import { IBaseErrorOptions } from '@elsikora/cladi';
+export default IBaseErrorOptions`} />


### PR DESCRIPTION
…eference

Added a step to clean the target directory before copying docs to prevent stale files from persisting. Also fixed an incorrect TSDoc reference in the error handling documentation from BaseContainer to IBaseErrorOptions.