### PR TITLE
build(config): update tsconfig paths to simplify imports

### DIFF
--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,7 +1,7 @@
 {
 	"compilerOptions": {
 		"alwaysStrict": true,
-		"baseUrl": "./",
+		"baseUrl": "./src",
 		"declaration": true,
 		"declarationMap": true,
 		"esModuleInterop": true,
@@ -16,10 +16,10 @@
 		"noUnusedParameters": true,
 		"outDir": "./dist",
 		"paths": {
-			"@application/*": ["src/application/*"],
-			"@domain/*": ["src/domain/*"],
-			"@infrastructure/*": ["src/infrastructure/*"],
-			"@presentation/*": ["src/presentation/*"]
+			"@application/*": ["application/*"],
+			"@domain/*": ["domain/*"],
+			"@infrastructure/*": ["infrastructure/*"],
+			"@presentation/*": ["presentation/*"]
 		},
 		"rootDir": "./src",
 		"skipLibCheck": true,


### PR DESCRIPTION
Changed the baseUrl from './' to './src' and simplified the path mappings by removing the 'src/' prefix from paths. This makes import paths more concise while maintaining the same functionality.